### PR TITLE
Fix asciidoctor.js invocation and version.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path = require('path');
-var asciidoc = ( require('asciidoctor.js')() ).Asciidoctor(true);
+var asciidoc = require('asciidoctor.js')();
 
 var rAsciidoc = /\.(adoc|asciidoc)$/;
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "plugin"
   ],
   "dependencies": {
-    "asciidoctor.js": "^1.5.0"
+    "asciidoctor.js": ">1.5.6-preview"
   },
   "devDependencies": {
     "assert": "^1.1.2",


### PR DESCRIPTION
Allows metalsmith-asciidoc to correctly invoke asciidoctor.js (this changed recently) and pull in recent versions including previews.